### PR TITLE
Make sure wit-bindgen-gen-wasmer-py uses forward references for named types

### DIFF
--- a/crates/gen-wasmer-py/src/source.rs
+++ b/crates/gen-wasmer-py/src/source.rs
@@ -199,7 +199,13 @@ impl<'s, 'd, 'i> SourceBuilder<'s, 'd, 'i> {
             Type::Id(id) => {
                 let ty = &self.iface.types[*id];
                 if let Some(name) = &ty.name {
+                    if forward_ref {
+                        self.push_str("'");
+                    }
                     self.push_str(&name.to_camel_case());
+                    if forward_ref {
+                        self.push_str("'");
+                    }
                     return;
                 }
                 match &ty.kind {
@@ -335,11 +341,11 @@ impl<'s, 'd, 'i> SourceBuilder<'s, 'd, 'i> {
     /// @dataclass
     /// class Foo0:
     ///     value: int
-    ///  
+    ///
     /// @dataclass
     /// class Foo1:
     ///     value: int
-    ///  
+    ///
     /// Foo = Union[Foo0, Foo1]
     /// ```
     pub fn print_union_wrapped(&mut self, name: &str, union: &Union, docs: &Docs) {


### PR DESCRIPTION
I was using `wit-bindgen-gen-wasmer-py` and noticed that you can get code like this:

```py
class Exports:
  @classmethod
  def from_path(...) -> Expected['Exports', Error]:
    ...

class Error:
  ...
```

In this case, `Exports.from_path()`'s return type references `Error` before the `Error` class has been defined, so we get a `NameError` when importing `bindings.py`.

```
$ ipython
> import wit_pack_py

---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-1-473065f48e2f> in <module>
----> 1 import wit_pack_py

~/Documents/wasmer/wit-pack/wit_pack_py/__init__.py in <module>
      5 from pathlib import Path
      6
----> 7 from .bindings import WitPack
      8
      9 store = Store()

~/Documents/wasmer/wit-pack/wit_pack_py/bindings.py in <module>
    208
    209
--> 210 class Exports:
    211
    212     _wasm_val: int

~/Documents/wasmer/wit-pack/wit_pack_py/bindings.py in Exports()
    240     def from_wit(
    241         cls, obj: "WitPack", name: str, contents: str
--> 242     ) -> Expected["Exports", Error]:
    243         memory = obj._memory
    244         realloc = obj._canonical_abi_realloc

NameError: name 'Error' is not defined
```